### PR TITLE
feat: add configurable web search

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,19 @@ NEWSAPI_KEY=            # required when SEARCH_PROVIDER=newsapi or hybrid
 
 `SEARCH_PROVIDER` を `cse` または `hybrid` に設定する場合は `CSE_API_KEY` と `CSE_CX` を、`newsapi` または `hybrid` に設定する場合は `NEWSAPI_KEY` をそれぞれ設定してください。
 
+### Web検索の使用例
+
+```python
+from services.search_enhancer import SearchEnhancerService
+
+service = SearchEnhancerService()
+result = service.enhanced_search("最新のAI動向", industry="IT")
+for item in result["search_results"]:
+    print(item["title"], item["url"])
+```
+
+環境変数 `SEARCH_PROVIDER` によって使用する検索プロバイダーを切り替えられます。`hybrid` を選択すると CSE と NewsAPI の結果を統合して返します。
+
 ## GCPへの移行
 
 `migrate-to-gcp.sh` を使うとアプリを Google Cloud にデプロイできます。非対話モードでの実行例:

--- a/docs/WEB_SEARCH.md
+++ b/docs/WEB_SEARCH.md
@@ -1,0 +1,23 @@
+# Web Search Configuration
+
+This project can enrich analysis with external web results. Configure the following environment variables in your `.env` file:
+
+```bash
+SEARCH_PROVIDER=hybrid  # none|cse|newsapi|hybrid
+CSE_API_KEY=your-google-cse-key       # when using cse or hybrid
+CSE_CX=your-custom-search-engine-id   # when using cse or hybrid
+NEWSAPI_KEY=your-newsapi-key          # when using newsapi or hybrid
+```
+
+## Usage
+
+```python
+from services.search_enhancer import SearchEnhancerService
+
+service = SearchEnhancerService()
+result = service.enhanced_search("最新のAI動向", industry="IT")
+for item in result["search_results"]:
+    print(item["title"], item["url"])
+```
+
+The search provider is selected via `SEARCH_PROVIDER`. When set to `hybrid`, results from both providers are merged and ranked.

--- a/providers/search_provider.py
+++ b/providers/search_provider.py
@@ -23,22 +23,31 @@ class WebSearchProvider:
         """設定から検索設定を取得"""
         if self.settings_manager:
             try:
-                settings = self.settings_manager.load_settings()
-                # 型をサニタイズ（Mock対策）
-                provider = getattr(settings, 'search_provider', self.search_provider)
-                limit = getattr(settings, 'search_results_limit', 5)
-                doms = getattr(settings, 'search_trusted_domains', None)
+                cfg = self.settings_manager.get_search_config()
+                provider = cfg.get("provider", self.search_provider)
+                try:
+                    provider = provider.value  # type: ignore[attr-defined]
+                except Exception:
+                    pass
+                provider = str(provider)
+                limit = cfg.get("limit", 5)
+                if not isinstance(limit, int):
+                    try:
+                        limit = int(limit)  # type: ignore[arg-type]
+                    except Exception:
+                        limit = 5
+                doms = cfg.get("trusted_domains", [])
                 if not isinstance(doms, list):
                     doms = []
-                wnd = getattr(settings, 'search_time_window_days', 60)
+                wnd = cfg.get("time_window_days", 60)
                 if not isinstance(wnd, int):
                     try:
                         wnd = int(wnd)  # type: ignore[arg-type]
                     except Exception:
                         wnd = 60
-                lang = getattr(settings, 'search_language', 'ja')
+                lang = cfg.get("language", "ja")
                 if not isinstance(lang, str):
-                    lang = 'ja'
+                    lang = "ja"
                 return {
                     "provider": provider,
                     "limit": limit,

--- a/services/di_container.py
+++ b/services/di_container.py
@@ -167,35 +167,66 @@ def configure_services() -> None:
     from services.security_utils import PromptSecurityManager
     from providers.llm_openai import EnhancedOpenAIProvider
     from services.usage_meter import UsageMeter
+    from services.settings_manager import SettingsManager
+    from providers.search_provider import WebSearchProvider
+    from services.search_enhancer import SearchEnhancerService
 
     # LLMプロバイダー
-    _default_collection.add_singleton(
+    _default_collection.add_factory(
         EnhancedOpenAIProvider,
-        factory=lambda: EnhancedOpenAIProvider()
+        lambda: EnhancedOpenAIProvider(),
+        lifetime=ServiceLifetime.SINGLETON,
     )
 
     # プロンプトマネージャー
-    _default_collection.add_singleton(
+    _default_collection.add_factory(
         EnhancedPromptManager,
-        factory=lambda: EnhancedPromptManager()
+        lambda: EnhancedPromptManager(),
+        lifetime=ServiceLifetime.SINGLETON,
     )
 
     # スキーママネージャー
-    _default_collection.add_singleton(
+    _default_collection.add_factory(
         UnifiedSchemaManager,
-        factory=lambda: UnifiedSchemaManager()
+        lambda: UnifiedSchemaManager(),
+        lifetime=ServiceLifetime.SINGLETON,
     )
 
     # セキュリティマネージャー
-    _default_collection.add_singleton(
+    _default_collection.add_factory(
         PromptSecurityManager,
-        factory=lambda: PromptSecurityManager()
+        lambda: PromptSecurityManager(),
+        lifetime=ServiceLifetime.SINGLETON,
     )
 
     # ユーセージメーター
     _default_collection.add_singleton(
         UsageMeter,
         instance=UsageMeter()
+    )
+
+    # 設定マネージャー
+    _default_collection.add_singleton(
+        SettingsManager,
+        instance=SettingsManager()
+    )
+
+    # Web検索プロバイダー
+    _default_collection.add_factory(
+        WebSearchProvider,
+        lambda: WebSearchProvider(_default_provider.get_service(SettingsManager)),
+        lifetime=ServiceLifetime.SINGLETON,
+    )
+
+    # 検索高度化サービス
+    _default_collection.add_factory(
+        SearchEnhancerService,
+        lambda: SearchEnhancerService(
+            _default_provider.get_service(SettingsManager),
+            _default_provider.get_service_optional(EnhancedOpenAIProvider),
+            _default_provider.get_service(WebSearchProvider),
+        ),
+        lifetime=ServiceLifetime.SINGLETON,
     )
 
     # サービスロケーターの設定

--- a/services/search_enhancer.py
+++ b/services/search_enhancer.py
@@ -19,8 +19,8 @@ from services.utils import escape_braces, sanitize_for_prompt
 
 class SearchEnhancerService:
     """検索機能の高度化サービス"""
-    
-    def __init__(self, settings_manager=None, llm_provider=None):
+
+    def __init__(self, settings_manager=None, llm_provider=None, search_provider=None):
         self.settings_manager = settings_manager
         self.logger = Logger()
         self.error_handler = ErrorHandler(self.logger)
@@ -35,7 +35,7 @@ class SearchEnhancerService:
                 self.logger.warning(f"OpenAIProviderの初期化に失敗: {e}")
                 self.llm_provider = None
 
-        self.search_provider = WebSearchProvider(settings_manager)
+        self.search_provider = search_provider or WebSearchProvider(settings_manager)
         
     def _load_prompts(self) -> Dict[str, Any]:
         """プロンプトテンプレートを読み込み"""

--- a/services/settings_manager.py
+++ b/services/settings_manager.py
@@ -106,9 +106,14 @@ class SettingsManager:
     def get_search_config(self) -> Dict[str, Any]:
         """検索設定を取得"""
         settings = self.load_settings()
+        env_provider = os.getenv("SEARCH_PROVIDER")
+        provider = env_provider or settings.search_provider
         return {
-            "provider": settings.search_provider,
-            "limit": settings.search_results_limit
+            "provider": provider,
+            "limit": settings.search_results_limit,
+            "trusted_domains": settings.search_trusted_domains,
+            "time_window_days": settings.search_time_window_days,
+            "language": settings.search_language,
         }
     
     def get_ui_config(self) -> Dict[str, Any]:

--- a/tests/test_search_provider.py
+++ b/tests/test_search_provider.py
@@ -105,3 +105,42 @@ def test_newsapi_with_fallback_uses_stub(mocker):
     mocker.patch.object(provider, "_rank_results", side_effect=lambda items, q, n: items[:n])
     results = provider._search_newsapi_with_fallback("q", 1)
     assert results[0]["source"] == "stub"
+
+
+def test_search_cse_mode(monkeypatch):
+    monkeypatch.setenv("SEARCH_PROVIDER", "cse")
+    provider = WebSearchProvider()
+    monkeypatch.setattr(
+        provider,
+        "_search_cse_with_fallback",
+        lambda q, n: [{"title": "a", "url": "https://cse.com", "snippet": "s", "source": "cse", "published_at": None}],
+    )
+    monkeypatch.setattr(provider, "_rank_results", lambda items, q, n: items[:n])
+    results = provider.search("q", num=1)
+    assert results[0]["source"] == "cse"
+
+
+def test_search_newsapi_mode(monkeypatch):
+    monkeypatch.setenv("SEARCH_PROVIDER", "newsapi")
+    provider = WebSearchProvider()
+    monkeypatch.setattr(
+        provider,
+        "_search_newsapi_with_fallback",
+        lambda q, n: [{"title": "a", "url": "https://n.com", "snippet": "s", "source": "newsapi", "published_at": None}],
+    )
+    monkeypatch.setattr(provider, "_rank_results", lambda items, q, n: items[:n])
+    results = provider.search("q", num=1)
+    assert results[0]["source"] == "newsapi"
+
+
+def test_search_hybrid_mode(monkeypatch):
+    monkeypatch.setenv("SEARCH_PROVIDER", "hybrid")
+    provider = WebSearchProvider()
+    monkeypatch.setattr(
+        provider,
+        "_search_hybrid",
+        lambda q, n, limit: [{"title": "a", "url": "https://h.com", "snippet": "s", "source": "hybrid", "published_at": None}],
+    )
+    monkeypatch.setattr(provider, "_rank_results", lambda items, q, n: items[:n])
+    results = provider.search("q", num=1)
+    assert results[0]["source"] == "hybrid"


### PR DESCRIPTION
## Summary
- expand settings to expose web search provider options
- wire WebSearchProvider and SearchEnhancerService into DI container
- document SEARCH_PROVIDER, CSE_API_KEY, and NEWSAPI_KEY with usage examples

## Testing
- `pytest tests/test_search_provider.py -q`
- `pytest -q` *(fails: IndentationError in app/pages/pre_advice.py)*

------
https://chatgpt.com/codex/tasks/task_e_68b4357b94088333b31d2c5c7980da21